### PR TITLE
sys.abi_info: Use Sphinx markup for attributes

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -27,22 +27,31 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
    The following attributes are available:
 
-   *pointer_bits* is the width of pointers in bits, as an integer, equivalent
-   to ``8 * sizeof(void *)``, i.e. usually ``32`` or ``64``.
+   .. attribute:: abi_info.pointer_bits
 
-   *free_threaded* is a boolean indicating whether the interpreter supports
-   running in free-threaded mode (i.e. with the GIL disabled).
-   This reflects the presence of the :option:`--disable-gil` configure option,
-   or the setting of the ``DisableGil`` property on Windows, respectively.
+      The width of pointers in bits, as an integer, equivalent
+      to ``8 * sizeof(void *)``. Usually, this is  ``32`` or ``64``.
 
-   *debug* is a boolean indicating whether the interpreter was built in
-   :ref:`debug mode <debug-build>`.
-   This reflects the presence of the :option:`--with-pydebug` configure option,
-   or the ``Debug`` configuration on Windows, respectively.
+   .. attribute:: abi_info.free_threaded
 
-   *byteorder* is a string indicating the native byte order, either ``'big'``
-   or ``'little'``.
-   This is the same as the :data:`sys.byteorder` attribute.
+      A boolean indicating whether the interpreter was built with
+      :term:`free threading` support.
+      This reflects the presence of the :option:`--disable-gil` configure
+      option, or the setting of the ``DisableGil`` property on Windows,
+      respectively.
+
+   .. attribute:: abi_info.debug
+
+      A boolean indicating whether the interpreter was built in
+      :ref:`debug mode <debug-build>`.
+      This reflects the presence of the :option:`--with-pydebug` configure
+      option, or the ``Debug`` configuration on Windows, respectively.
+
+   .. attribute:: abi_info.byteorder
+
+      A string indicating the native byte order, either ``'big'`` or
+      ``'little'``.
+      This is the same as the :data:`byteorder` attribute.
 
 
 .. data:: abiflags


### PR DESCRIPTION
Hello,
This should make the attributes show up in search & Intersphinx properly.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--3.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->